### PR TITLE
hotfix/avoid-versions-different-than-latest

### DIFF
--- a/scripts/semver.sh
+++ b/scripts/semver.sh
@@ -28,10 +28,12 @@ done
 
 shift $(($OPTIND - 1))
 
+repositoryName=$1
+
 echo "cd to github workspace"
 cd ${GITHUB_WORKSPACE}
 
-version=$(git for-each-ref refs/tags/ --count=1 --sort=-version:refname --format='%(refname:short)')
+version=$(curl -sL https://api.github.com/repos/$repositoryName/releases/latest | jq -r ".tag_name")
 echo "Actual version: ${version}"
 
 if [ -z ${version} ]


### PR DESCRIPTION
Fixing error that version could be different from the latest published semver tag ex: 'alpha'

Signed-off-by: nathanmartinszup <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-devkit/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
