### PR TITLE
make coverage script fail on go test

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 THRESHOLD=$1
 PROJECT=$2
 


### PR DESCRIPTION
Previously if some test fail during go test execution the coverage
script still finish with exit code 0. This commit change the behaviour
of coverage script to fail if go test command fail.

Co-authored-by: Matheus Alcantara matheus.alcantara@zup.com.br

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-devkit/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
