### PR TITLE
vulnerability: add new field to represent invalid vulnerability hash

### DIFF
--- a/pkg/entities/vulnerability/vulnerability.go
+++ b/pkg/entities/vulnerability/vulnerability.go
@@ -37,13 +37,30 @@ type Vulnerability struct {
 	SecurityTool    tools.Tool            `json:"securityTool" gorm:"Column:security_tool" example:"HorusecEngine" enums:"HorusecEngine,GoSec,SecurityCodeScan,Brakeman,Safety,Bandit,NpmAudit,YarnAudit,GitLeaks,TfSec,Semgrep,Flawfinder,PhpCS,MixAudit,Sobelow,ShellCheck,BundlerAudit"`
 	Language        languages.Language    `json:"language" gorm:"Column:language" example:"Leaks" enums:"Go,C#,Dart,Ruby,Python,Java,Kotlin,Javascript,Typescript,Leaks,HCL,C,PHP,HTML,Generic,YAML,Elixir,Shell,Nginx"`
 	Severity        severities.Severity   `json:"severity" gorm:"Column:severity" example:"CRITICAL" enums:"CRITICAL, HIGH, MEDIUM, LOW, INFO"`
-	VulnHash        string                `json:"vulnHash" gorm:"Column:vuln_hash" example:"8bcac7908eb950419537b91e19adc83ce2c9cbfdacf4f81157fdadfec11f7017"`
 	Type            vulnerability.Type    `json:"type" gorm:"Column:type" example:"Vulnerability" enums:"Vulnerability, Risk Accepted, False Positive, Corrected"`
 	CommitAuthor    string                `json:"commitAuthor" gorm:"Column:commit_author" example:"horusec"`
 	CommitEmail     string                `json:"commitEmail" gorm:"Column:commit_email" example:"horusec@zup.com.br"`
 	CommitHash      string                `json:"commitHash" gorm:"Column:commit_hash" example:"a21fa164c00a15f3e91f5ee6659cb6a793b39a8d"`
 	CommitMessage   string                `json:"commitMessage" gorm:"Column:commit_message" example:"Initial commit"`
 	CommitDate      string                `json:"commitDate" gorm:"Column:commit_date" example:"2021-12-30"`
+
+	// RuleID is the rule id used to generate Vulnerability.
+	// This field can bem empty if Vulnerability was not generated from horusec-engine.
+	RuleID string `json:"-" gorm:"-" swaggerignore:"true"`
+
+	// VulnHash is the vulnerability hash
+	VulnHash string `json:"vulnHash" gorm:"Column:vuln_hash" example:"8bcac7908eb950419537b91e19adc83ce2c9cbfdacf4f81157fdadfec11f7017"`
+
+	// VulnHashInvalid is a breaking change version of VulnHash. On version v2.6.0 we introduce a bug
+	// that generate different hashes which cause a breaking change. Since some users update their
+	// false positive/risk accept hashes to new version and some users not we need to check both of
+	// them to ignore.
+	//
+	// NOTE: This field should **only** be used to compare false positive and risk accept hashes from
+	// config file on cli, other cases should use VulnHash.
+	//
+	// For more info see https://github.com/ZupIT/horusec/issues/680
+	VulnHashInvalid string `json:"-" gorm:"-" swaggerignore:"true"`
 }
 
 func (v *Vulnerability) GetTable() string {


### PR DESCRIPTION
A new field VulnHashInvalid was added on vulnerability struct to allow
cli match the valid and invalid hashes of vulnerability. For more info
see ZupIT/horusec#680

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-devkit/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
