### PR TITLE
entities/vulnerability:feature - adding new vulnerability fields 

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -394,12 +394,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2 h1:+iNTcqQJy0OZ5jk6a5NLib47eqXK8uYcPX+O4+cBpEM=
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
-github.com/swaggo/http-swagger v1.2.0 h1:G5EBD5nvw379l2sFhact660YDT++eLviczLPrgNw/lU=
-github.com/swaggo/http-swagger v1.2.0/go.mod h1:P7+V1SLG2zloe+VvAGL7WgFimhJACaBLAv2N7YQ0ikI=
 github.com/swaggo/http-swagger v1.2.5 h1:iDWoHpJMLNo4nwGOPXsOoqlB9wB6M4xgjhws8x3KQcs=
 github.com/swaggo/http-swagger v1.2.5/go.mod h1:CcoICgY3yVDk2u1LQUCMHbAj0fjlxIX+873psXlIKNA=
-github.com/swaggo/swag v1.7.8 h1:w249t0l/kc/DKMGlS0fppNJQxKyJ8heNaUWB6nsH3zc=
-github.com/swaggo/swag v1.7.8/go.mod h1:gZ+TJ2w/Ve1RwQsA2IRoSOTidHz6DX+PIG8GWvbnoLU=
 github.com/swaggo/swag v1.7.9 h1:6vCG5mm43ebDzGlZPMGYrYI4zKFfOr5kicQX8qjeDwc=
 github.com/swaggo/swag v1.7.9/go.mod h1:gZ+TJ2w/Ve1RwQsA2IRoSOTidHz6DX+PIG8GWvbnoLU=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
@@ -441,8 +437,6 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed h1:YoWVYYAfvQ4ddHv3OKmIvX7NCAhFGTj62VP2l2kfBbA=
-golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220213190939-1e6e3497d506 h1:EuGTJDfeg/PGZJp3gq1K+14eSLFTsrj1eg8KQuiUyKg=
 golang.org/x/crypto v0.0.0-20220213190939-1e6e3497d506/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/entities/analysis/analysis.go
+++ b/pkg/entities/analysis/analysis.go
@@ -35,6 +35,12 @@ type Analysis struct {
 	CreatedAt               time.Time                 `json:"createdAt" gorm:"Column:created_at" example:"2021-12-30T23:59:59Z"`
 	FinishedAt              time.Time                 `json:"finishedAt" gorm:"Column:finished_at" example:"2021-12-30T23:59:59Z"`
 	AnalysisVulnerabilities []AnalysisVulnerabilities `json:"analysisVulnerabilities" gorm:"foreignKey:AnalysisID;references:ID"`
+
+	// Warnings this field has an idea of centralizing all warnings that need to printed in the end of the analysis,
+	// simplifying our warning management. After start an analysis we cannot print any message or the loading will
+	// break, the idea are that we add all necessary warnings into this field and avoid these messages during the
+	// loading phase.
+	Warnings []string `json:"-"`
 }
 
 func (a *Analysis) GetTable() string {
@@ -144,4 +150,8 @@ func (a *Analysis) GetDataWithoutVulnerabilities() *Analysis {
 		CreatedAt:      a.CreatedAt,
 		FinishedAt:     a.FinishedAt,
 	}
+}
+
+func (a *Analysis) AddWarning(warning string) {
+	a.Warnings = append(a.Warnings, warning)
 }

--- a/pkg/entities/analysis/analysis_test.go
+++ b/pkg/entities/analysis/analysis_test.go
@@ -236,3 +236,13 @@ func TestGetDataWithoutVulnerabilities(t *testing.T) {
 		assert.NotEmpty(t, result.FinishedAt)
 	})
 }
+
+func TestAddWarning(t *testing.T) {
+	t.Run("should success append a new warning", func(t *testing.T) {
+		analysis := new(Analysis)
+
+		analysis.AddWarning("test")
+
+		assert.Len(t, analysis.Warnings, 1)
+	})
+}

--- a/pkg/entities/vulnerability/vulnerability.go
+++ b/pkg/entities/vulnerability/vulnerability.go
@@ -24,6 +24,9 @@ import (
 	"github.com/ZupIT/horusec-devkit/pkg/enums/vulnerability"
 )
 
+// Vulnerability this struct represents a possible vulnerability and contains all necessary data to identify it.
+// TODO: The fields CWEs, CVEs, Mitigation, Reference, SafeExample, UnsafeExample are going to be ignored until we
+// start to fill the data into the engine rules. After completed it's necessary to add then into the json notation.
 //nolint:lll // notations need more than 130 characters
 type Vulnerability struct {
 	VulnerabilityID uuid.UUID             `json:"vulnerabilityID" gorm:"Column:vulnerability_id" example:"00000000-0000-0000-0000-000000000000"`
@@ -37,6 +40,12 @@ type Vulnerability struct {
 	Language        languages.Language    `json:"language" gorm:"Column:language" example:"Leaks" enums:"Go,C#,Dart,Ruby,Python,Java,Kotlin,Javascript,Typescript,Leaks,HCL,C,PHP,HTML,Generic,YAML,Elixir,Shell,Nginx"`
 	Severity        severities.Severity   `json:"severity" gorm:"Column:severity" example:"CRITICAL" enums:"CRITICAL, HIGH, MEDIUM, LOW, INFO"`
 	Type            vulnerability.Type    `json:"type" gorm:"Column:type" example:"Vulnerability" enums:"Vulnerability, Risk Accepted, False Positive, Corrected"`
+	CWEs            []string              `json:"-" gorm:"-" example:"[\"https://cwe.mitre.org/data/definitions/000.html\"]"`
+	CVEs            []string              `json:"-" gorm:"-" example:"[\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-0000-00000\"]"`
+	Mitigation      string                `json:"-" gorm:"-" example:"Use a secret manager or environment variable"`
+	Reference       string                `json:"-" gorm:"-" example:"https://example.com"`
+	SafeExample     string                `json:"-" gorm:"-" example:"setPassword(env.get(\"HORUSEC_PASSWORD\"))"`
+	UnsafeExample   string                `json:"-" gorm:"-" example:"setPassword(\"s@f3P@a$$w0rd\")"`
 	CommitAuthor    string                `json:"commitAuthor" gorm:"Column:commit_author" example:"horusec"`
 	CommitEmail     string                `json:"commitEmail" gorm:"Column:commit_email" example:"horusec@zup.com.br"`
 	CommitHash      string                `json:"commitHash" gorm:"Column:commit_hash" example:"a21fa164c00a15f3e91f5ee6659cb6a793b39a8d"`
@@ -50,16 +59,12 @@ type Vulnerability struct {
 	// VulnHash is the vulnerability hash
 	VulnHash string `json:"vulnHash" gorm:"Column:vuln_hash" example:"8bcac7908eb950419537b91e19adc83ce2c9cbfdacf4f81157fdadfec11f7017"`
 
-	// VulnHashInvalid is a breaking change version of VulnHash. On version v2.6.0 we introduce a bug
-	// that generate different hashes which cause a breaking change. Since some users update their
-	// false positive/risk accept hashes to new version and some users not we need to check both of
-	// them to ignore.
-	//
-	// NOTE: This field should **only** be used to compare false positive and risk accept hashes from
-	// config file on cli, other cases should use VulnHash.
-	//
-	// For more info see https://github.com/ZupIT/horusec/issues/680
-	VulnHashInvalid string `json:"-" gorm:"-" swaggerignore:"true"`
+	// DeprecatedHashes contains some hashes generated in different versions and in different ways, but which are
+	// still valid. This field exists only to avoid breaking changes to the users and will be removed in a future
+	// release. Until then, when a hash of this field is identified, an alert will be displayed to the user so
+	// that he can change this hash to the updated one, which is in the VulnHash field
+	// TODO: This will be removed after the release v2.10.0 of the Horusec CLI be released.
+	DeprecatedHashes []string `json:"deprecatedHashes" gorm:"-" example:""`
 
 	SecurityToolVersion string `json:"securityToolVersion"`
 	SecurityToolInfoURI string `json:"securityToolInfoUri"`


### PR DESCRIPTION
  Added CWEs, CVEs, Mitigation, Reference, SafeExample, UnsafeExample,
    OldHashes into the vulnerability struct. This fields are going to be
    used to inform a more depper output from Horusec. OldHashes replaces the
    VulnHashInvalid fields, now it's an array that contains all hashes that
    are no more generated, but still valid. This is necessary to avoid
    breaking changes, but it will be removed in a near future.

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-devkit/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
